### PR TITLE
fix: converte themeId to number

### DIFF
--- a/src/utils/SaveConfigurationFile.ts
+++ b/src/utils/SaveConfigurationFile.ts
@@ -19,12 +19,13 @@ export function saveConfigurationFile({
     const fileDataAsObject = {
         ':api_key': key,
         ':password': password,
-        ':theme_id': themeId,
+        ':theme_id': themeId ? Number(themeId) : undefined,
         ':preview_url': previewUrl,
         ':debug': debug,
     };
 
     const configFileData = yaml.stringify(fileDataAsObject);
+    console.log('YAML Data:', configFileData);
 
     return fsp
         .writeFile('config.yml', configFileData)

--- a/src/utils/SaveConfigurationFile.ts
+++ b/src/utils/SaveConfigurationFile.ts
@@ -25,7 +25,6 @@ export function saveConfigurationFile({
     };
 
     const configFileData = yaml.stringify(fileDataAsObject);
-    console.log('YAML Data:', configFileData);
 
     return fsp
         .writeFile('config.yml', configFileData)


### PR DESCRIPTION
Garante que o valor de themeId seja tratado como número antes de ser serializado para o arquivo config.yml.

- Mudança: Adicionei uma conversão explícita de themeId para o tipo number utilizando a função Number(). Isso assegura que o valor de themeId será armazenado corretamente como um número no arquivo YAML, evitando que ele seja interpretado ou serializado como uma string.

Acredito que com esta alteração, o  themeId será um number ao criar o config.yml, garantido que o arquivo seja criado seguindo o formato do SDK