### PR TITLE
Corrige a remoção de arquivos

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tray-tecnologia/cli",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "type": "module",
   "description": "CLI designed to help developers create great themes for Tray E-commerce.",
   "license": "GPL-3.0-only",
@@ -16,7 +16,7 @@
     "lint": "eslint --cache",
     "type:check": "tsc --build --force",
     "build": "vite build",
-    "postbuild": "chmod +x dist/bin/cli.js",
+    "watch": "vite build --watch",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/cli/setBinaryPermission.ts
+++ b/packages/cli/setBinaryPermission.ts
@@ -1,0 +1,20 @@
+import { execSync } from 'child_process';
+import type { Plugin, ResolvedConfig } from 'vite';
+
+export default function setBinaryPermission(): Plugin {
+  let config: ResolvedConfig;
+
+  return {
+    name: 'set-binary-permission',
+
+    configResolved(resolvedConfig) {
+      config = resolvedConfig;
+    },
+
+    async closeBundle() {
+      if (config.mode === 'production') {
+        execSync('chmod +x dist/bin/cli.js');
+      }
+    },
+  };
+}

--- a/packages/cli/src/Tray.ts
+++ b/packages/cli/src/Tray.ts
@@ -253,15 +253,20 @@ export class Tray {
    * @return {Promise} Returns RemoveCommandResponse object if promises resolves, CliError or ApiError otherwise.
    */
   async remove(files: string[]): Promise<RemoveCommandResponse> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const errors: any[] = [];
 
-    const allFiles = await this.api.getThemeAssets();
+    const themeFiles = await this.api.getThemeAssets();
 
-    if (!allFiles?.data) {
+    if (!themeFiles?.data) {
       throw new ThemeFilesNotFoundError();
     }
 
-    const filesToRemove = allFiles.data.filter((file) => files.includes(file.path));
+    const filesToRemove = themeFiles.data.filter((file) => {
+      const normalizedPath = file.path.startsWith('/') ? file.path.substring(1) : file.path;
+
+      return files.includes(normalizedPath);
+    });
 
     const promises = filesToRemove.map((file) =>
       this.api.deleteThemeAsset(file.id).catch((error) => errors.push({ file, error }))

--- a/packages/cli/src/cli/commands/Remove.ts
+++ b/packages/cli/src/cli/commands/Remove.ts
@@ -37,7 +37,7 @@ export default function remove() {
           const loader = ora(`Deleting files...`).start();
 
           const response = await tray.remove(globbed);
-          
+
           if (response.fails.length) {
             const errorCount = response.fails.length;
             const errors = response.fails
@@ -49,9 +49,7 @@ export default function remove() {
                 `Unable to delete files correctly due to errors. Files affected listed bellow:`
               );
             } else {
-              loader.warn(
-                `Files deleted with ${errorCount} errors. Files affected listed bellow:`
-              );
+              loader.warn(`Files deleted with ${errorCount} errors. Files affected listed bellow:`);
             }
 
             console.log(errors);
@@ -59,7 +57,9 @@ export default function remove() {
             loader.succeed(`Files deleted.`);
           }
         } catch (error) {
-          ora().start().fail((error as Error).toString());
+          ora()
+            .start()
+            .fail((error as Error).toString());
         }
       } else {
         ora().fail('Operation aborted by user');

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["vite.config.ts", "src/**/*"],
+  "include": ["vite.config.ts", "setBinaryPermission.ts", "src/**/*"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "module": "ESNext",

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
+import setBinaryPermission from './setBinaryPermission';
 
 export default defineConfig({
   plugins: [
@@ -13,10 +14,11 @@ export default defineConfig({
           content,
         };
       },
-      afterBuild: () => {
-        setTimeout(() => process.exit(0), 300);
-      },
+      // afterBuild: () => {
+      //   setTimeout(() => process.exit(0), 300);
+      // },
     }),
+    setBinaryPermission(),
   ],
   build: {
     target: 'node22',

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -14,9 +14,6 @@ export default defineConfig({
           content,
         };
       },
-      // afterBuild: () => {
-      //   setTimeout(() => process.exit(0), 300);
-      // },
     }),
     setBinaryPermission(),
   ],

--- a/packages/config-eslint/src/base.ts
+++ b/packages/config-eslint/src/base.ts
@@ -15,6 +15,9 @@ export default tseslint.config(
   {
     languageOptions: {
       globals: globals.browser,
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
   },
   eslint.configs.recommended,
@@ -108,10 +111,6 @@ export default tseslint.config(
       ],
       'no-restricted-syntax': [
         'error',
-        {
-          selector: 'ExportDefaultDeclaration',
-          message: 'Prefer named exports',
-        }, // Block default exports
         {
           selector: 'ImportDeclaration[specifiers.length = 0]',
           message: 'Empty imports are not allowed',

--- a/packages/theme-sdk/.env
+++ b/packages/theme-sdk/.env
@@ -1,2 +1,2 @@
 VITE_API_URL="https://app.studio.tray.net.br/api/cli/v1"
-VITE_PACKAGE_VERSION="2.0.0-alpha.1"
+VITE_PACKAGE_VERSION="2.0.0-alpha.2"


### PR DESCRIPTION
Ao passar um arquivo o comando não verificava se existia ou não uma barra inicial no path, não casando com os arquivos retornados do servidor,  que geralmente incluem essa barra inicia. Isso fazia com que o arquivo não fosse removido. O ajuste corrige esse problema.