### PR TITLE
Processa download estáticos em parte

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tray-tecnologia/cli",
-  "version": "2.0.0-beta-1",
+  "version": "2.0.0-beta-2",
   "type": "module",
   "description": "CLI designed to help developers create great themes for Tray E-commerce.",
   "license": "GPL-3.0-only",
@@ -29,6 +29,7 @@
     "glob": "^11.0.3",
     "open": "^10.1.0",
     "ora": "^8.2.0",
+    "p-limit": "^4.0.0",
     "slash": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/cli/src/Tray.ts
+++ b/packages/cli/src/Tray.ts
@@ -1,6 +1,8 @@
 import Sdk from '@tray-tecnologia/theme-sdk';
 import { globSync } from 'glob';
 import axios from 'axios';
+import pLimit from 'p-limit';
+import type { LimitFunction } from 'p-limit';
 
 import {
   SaveConfigurationFileError,
@@ -27,6 +29,7 @@ export class Tray {
   previewUrl?: string;
   readonly debug: boolean;
   readonly api: Sdk;
+  readonly limit: LimitFunction;
 
   /**
    * Create new Tray instance
@@ -37,6 +40,7 @@ export class Tray {
     this.themeId = themeId;
     this.previewUrl = previewUrl;
     this.debug = debug;
+    this.limit = pLimit(100);
 
     this.api = new Sdk({
       token: this.token,
@@ -134,17 +138,19 @@ export class Tray {
 
     // Download paralelo de arquivos públicos
     const publicPromises = publicAssets.map(async (asset) => {
-      try {
-        const response = await axios.get(asset.uri as string, {
-          responseType: 'arraybuffer',
-          timeout: 30000,
-        });
+      return this.limit(async () => {
+        try {
+          const response = await axios.get(asset.uri as string, {
+            responseType: 'arraybuffer',
+            timeout: 120000,
+          });
 
-        const buffer = Buffer.from(response.data);
-        await saveThemeAssetFile(asset.path, buffer);
-      } catch (error) {
-        errors.push({ file: asset.path, error: new FileNotFoundError({ file: asset.path }) });
-      }
+          const buffer = Buffer.from(response.data);
+          await saveThemeAssetFile(asset.path, buffer);
+        } catch (error) {
+          errors.push({ file: asset.path, error: new FileNotFoundError({ file: asset.path }) });
+        }
+      });
     });
 
     // Download paralelo de arquivos dinâmicos


### PR DESCRIPTION
### Descrição 

Corrige problema no qual se o tema possuir muitos arquivos estáticos o CLI tenta realizar o download simultâneo de todos os arquivo, gerando um gargalo no sistema, levando a erros de rede. Implementado limitação para no máximo 100 arquivos simultâneos.