### PR TITLE
Permite underline no nome dos arquivos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6967,7 +6967,7 @@
     },
     "packages/cli": {
       "name": "@tray-tecnologia/cli",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@inquirer/prompts": "^7.6.0",
@@ -7040,7 +7040,7 @@
     },
     "packages/theme-sdk": {
       "name": "@tray-tecnologia/theme-sdk",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "axios": "^1.9.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tray-tecnologia/cli",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "type": "module",
   "description": "CLI designed to help developers create great themes for Tray E-commerce.",
   "license": "GPL-3.0-only",

--- a/packages/theme-sdk/.env
+++ b/packages/theme-sdk/.env
@@ -1,2 +1,2 @@
 VITE_API_URL="https://app.studio.tray.net.br/api/cli/v1"
-VITE_PACKAGE_VERSION="2.0.0-rc.1"
+VITE_PACKAGE_VERSION="2.0.0-rc.2"

--- a/packages/theme-sdk/package.json
+++ b/packages/theme-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tray-tecnologia/theme-sdk",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "type": "module",
   "description": "Theme SDK to interact with Studio API",
   "license": "GPL-3.0-only",

--- a/packages/theme-sdk/readme.md
+++ b/packages/theme-sdk/readme.md
@@ -43,7 +43,7 @@ Os temas precisam seguir uma estrutura bem determinada, caso contrário os arqui
 Se atente também as seguintes regras:
 - Somente as pastas `css`, `img`, `elements` e `js` suportam subpastas livremente. Tentar criar pastas nas outras pastas irá gerar o erro [FolderNotAllowedError](#foldernotallowederror-sdk0009);
 - Somente os seguintes formatos são permitidos: `.ttf`, `.otf`, `.eot`, `.woff`, `.woff2`, `.jpg`, `.jpeg`, `.gif`, `.png`, `.svg`, `.css`, `.scss`, `.html`, `.js`, `.json`;
-- Os nome dos arquivos devem possuir somente letras, números, ponto `.` e traços `-`. Qualquer outro caractere irá resultar no erro [InvalidFilenameError](#invalidfilenameerror-sdk0010);
+- Os nome dos arquivos devem possuir somente letras, números, ponto `.`, underline `_` e traços `-`. Qualquer outro caractere irá resultar no erro [InvalidFilenameError](#invalidfilenameerror-sdk0010);
 
 ## Uso
 

--- a/packages/theme-sdk/src/errors/InvalidFilenameError.ts
+++ b/packages/theme-sdk/src/errors/InvalidFilenameError.ts
@@ -4,7 +4,7 @@ export class InvalidFilenameError extends BaseError {
   constructor() {
     super({
       code: 'SDK::0010',
-      message: `The filename contains invalid characters. Only letters, numbers, "." and "-" are allowed.`,
+      message: `The filename contains invalid characters. Only letters, numbers, ".", "_" and "-" are allowed.`,
     });
     this.name = 'InvalidFilenameError';
   }

--- a/packages/theme-sdk/src/utils/IsFileAllowed.ts
+++ b/packages/theme-sdk/src/utils/IsFileAllowed.ts
@@ -15,7 +15,7 @@ import { camelCase } from './camelCase';
  */
 function isNameValid(filename: string): Promise<boolean> {
   return new Promise((resolve, reject) => {
-    /^[A-Za-z0-9.-]+$/.test(filename) ? resolve(true) : reject(new InvalidFilenameError());
+    /^[A-Za-z0-9._-]+$/.test(filename) ? resolve(true) : reject(new InvalidFilenameError());
   });
 }
 


### PR DESCRIPTION
### Descrição

Anteriormente foi removido a possibilidade de criar arquivos com underline `_`. Isso pode gerar um problema pois é algo muito comum para os desenvolvedores. Essa issue retorna o comportamento anterior, permitindo underlines.