### PR TITLE
Permitir criar arquivos de configuração do editor dentro da pasta `configs` do tema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2167,6 +2167,7 @@
       "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -2217,6 +2218,7 @@
       "integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.41.0",
         "@typescript-eslint/types": "8.41.0",
@@ -2707,6 +2709,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2730,6 +2733,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2858,6 +2862,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
       "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -3251,6 +3256,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -3602,6 +3608,7 @@
       "integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4760,6 +4767,7 @@
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -6376,6 +6384,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6598,6 +6607,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tray-tecnologia/cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "CLI designed to help developers create great themes for Tray E-commerce.",
   "license": "GPL-3.0-only",

--- a/packages/cli/src/Tray.ts
+++ b/packages/cli/src/Tray.ts
@@ -67,9 +67,6 @@ export class Tray {
    */
   async configure(): Promise<string> {
     return await this.api.getTheme().then((response) => {
-      if (response?.data?.original_theme_id === 1897) {
-        throw new ThemeBlockedError();
-      }
 
       const fileData: ConfigurationFile = {
         token: this.token,

--- a/packages/theme-sdk/.env
+++ b/packages/theme-sdk/.env
@@ -1,2 +1,2 @@
 VITE_API_URL="https://app.studio.tray.net.br/api/cli/v1"
-VITE_PACKAGE_VERSION="2.0.0"
+VITE_PACKAGE_VERSION="2.0.1"

--- a/packages/theme-sdk/package.json
+++ b/packages/theme-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tray-tecnologia/theme-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "Theme SDK to interact with Studio API",
   "license": "GPL-3.0-only",

--- a/packages/theme-sdk/readme.md
+++ b/packages/theme-sdk/readme.md
@@ -41,7 +41,7 @@ Os temas precisam seguir uma estrutura bem determinada, caso contrário os arqui
 ```
 
 Se atente também as seguintes regras:
-- Somente as pastas `css`, `img`, `elements` e `js` suportam subpastas livremente. Tentar criar pastas nas outras pastas irá gerar o erro [FolderNotAllowedError](#foldernotallowederror-sdk0009);
+- Somente as pastas `configs`, `css`, `img`, `elements` e `js` suportam subpastas livremente. Tentar criar pastas nas outras pastas irá gerar o erro [FolderNotAllowedError](#foldernotallowederror-sdk0009);
 - Somente os seguintes formatos são permitidos: `.ttf`, `.otf`, `.eot`, `.woff`, `.woff2`, `.jpg`, `.jpeg`, `.gif`, `.png`, `.svg`, `.css`, `.scss`, `.html`, `.js`, `.json`;
 - Os nome dos arquivos devem possuir somente letras, números, ponto `.`, underline `_` e traços `-`. Qualquer outro caractere irá resultar no erro [InvalidFilenameError](#invalidfilenameerror-sdk0010);
 

--- a/packages/theme-sdk/src/utils/IsFileAllowed.ts
+++ b/packages/theme-sdk/src/utils/IsFileAllowed.ts
@@ -90,7 +90,7 @@ function isFolderValid(directories: string): Promise<boolean> {
  * @internal
  */
 function isSubfoldersAllowed(directories: string): Promise<boolean> {
-  const allowedSubFolders = ['pages', 'elements', 'css', 'img', 'js'];
+  const allowedSubFolders = ['pages', 'elements', 'css', 'img', 'js', 'configs'];
 
   if (!directories || directories === '') {
     return Promise.resolve(true);
@@ -128,6 +128,69 @@ function isSubfoldersAllowed(directories: string): Promise<boolean> {
         );
       }
     }
+
+    if (rootFolder === 'configs') {
+      if (folders.length > 3) {
+        return reject(
+          new FolderNotAllowedError(
+            'Configs only allows up to 2 levels of subfolders (editor/sections)'
+          )
+        );
+      }
+      if (folders.length >= 2 && folders[1] !== 'editor') {
+        return reject(
+          new FolderNotAllowedError('Configs only allows the editor subfolder')
+        );
+      }
+      if (folders.length === 3 && folders[2] !== 'sections') {
+        return reject(
+          new FolderNotAllowedError('Configs/editor only allows the sections subfolder')
+        );
+      }
+    }
+
+    resolve(true);
+  });
+}
+
+/**
+ * Verify if file follows specific rules for certain directories.
+ * @param {string} filename File name
+ * @param {string} extension File extension
+ * @param {string} directories Folders path
+ * @return {promise} True if promises resolves, BaseError otherwise.
+ * @internal
+ */
+function isFileRulesValid(filename: string, extension: string, directories: string): Promise<boolean> {
+  if (!directories || directories === '') {
+    return Promise.resolve(true);
+  }
+
+  // Normalize directory separators to support Windows and Unix
+  const normalizedPath = directories.replace(/\\/g, '/');
+  const cleanPath = normalizedPath.startsWith('/') ? normalizedPath.substring(1) : normalizedPath;
+  const folders = cleanPath.split('/');
+
+  return new Promise((resolve, reject) => {
+    // Rules for configs/editor and configs/editor/sections
+    if (folders[0] === 'configs' && folders.length >= 2 && folders[1] === 'editor') {
+      // Only .json files allowed in configs/editor and configs/editor/sections
+      if (extension.toLowerCase() !== '.json') {
+        return reject(
+          new FileExtensionNotAllowedError('.json')
+        );
+      }
+
+      // configs/editor - only global.json allowed
+      if (folders.length === 2 && filename !== 'global') {
+        return reject(
+          new FolderNotAllowedError('Only global.json is allowed in configs/editor directory')
+        );
+      }
+
+      // configs/editor/sections - any name allowed (but only .json already validated)
+    }
+
     resolve(true);
   });
 }
@@ -144,5 +207,6 @@ export function isFileAllowed(path: string): Promise<boolean> {
   return isNameValid(name)
     .then(() => isExtensionValid(extension))
     .then(() => isFolderValid(directories))
-    .then(() => isSubfoldersAllowed(directories));
+    .then(() => isSubfoldersAllowed(directories))
+    .then(() => isFileRulesValid(name, extension, directories));
 }


### PR DESCRIPTION
Com o novo editor de temas foi preciso permitir subir e editar os arquivos de configuração do tema, que ficaram no caminho `configs/editor` e `configs/editor/sections`.

Também foi removido a restrição de download do Tema Padrão 3.0

