### PR TITLE
Sobe as versões das dependências

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1651,15 +1651,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bundle-name": {
@@ -2439,9 +2439,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -3101,9 +3101,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -3658,9 +3658,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -3971,9 +3971,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -3991,7 +3991,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4856,11 +4856,11 @@
     },
     "packages/cli": {
       "name": "@tray-tecnologia/cli",
-      "version": "2.0.3",
+      "version": "2.0.5",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@inquirer/prompts": "^7.6.0",
-        "@tray-tecnologia/theme-sdk": "2.0.3",
+        "@tray-tecnologia/theme-sdk": "2.0.5",
         "axios-retry": "^4.5.0",
         "chalk": "^5.6.2",
         "chokidar": "^4.0.3",
@@ -5419,7 +5419,7 @@
     },
     "packages/theme-sdk": {
       "name": "@tray-tecnologia/theme-sdk",
-      "version": "2.0.3",
+      "version": "2.0.5",
       "license": "GPL-3.0-only",
       "dependencies": {
         "axios": "^1.16.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tray-tecnologia/cli",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "type": "module",
   "description": "CLI designed to help developers create great themes for Tray E-commerce.",
   "license": "GPL-3.0-only",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^7.6.0",
-    "@tray-tecnologia/theme-sdk": "2.0.4",
+    "@tray-tecnologia/theme-sdk": "2.0.5",
     "axios-retry": "^4.5.0",
     "chalk": "^5.6.2",
     "chokidar": "^4.0.3",

--- a/packages/theme-sdk/package.json
+++ b/packages/theme-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tray-tecnologia/theme-sdk",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "type": "module",
   "description": "Theme SDK to interact with Studio API",
   "license": "GPL-3.0-only",


### PR DESCRIPTION
Atualiza as versões adas dependências `brace-expression`, `fast-uri`, `js-yaml` e `postcss` para corrigir vulnerabilidades reportadas pelo dependabot.